### PR TITLE
- The line "use Test::NoWarnings;" not required in the 03-map.t script.

### DIFF
--- a/t/Map-Tube-Moscow/03-map.t
+++ b/t/Map-Tube-Moscow/03-map.t
@@ -4,8 +4,7 @@ use warnings;
 
 # Modules.
 use Map::Tube::Moscow;
-use Test::Map::Tube 'tests' => 2;
-use Test::NoWarnings;
+use Test::Map::Tube 'tests' => 1;
 
 # Test.
 ok_map(Map::Tube::Moscow->new, 'Test validity of map.');


### PR DESCRIPTION
Hi ,

Please review the suggested change.

Many Thanks.

Best Regards,
Mohammad S Anwar
